### PR TITLE
add strace files

### DIFF
--- a/scripts/collect_curiosity_logs.sh
+++ b/scripts/collect_curiosity_logs.sh
@@ -41,7 +41,15 @@ fi
 
 for core_file in ${CURIOSITY_DIR}/coredump.*; do
     if [ -f "$core_file" ]; then
+        echo "collecting coredump $core_file"
         file_list="$file_list $core_file"
+    fi
+done
+
+for strace_file in ${CURIOSITY_DIR}/straced_monitor*.log; do
+    if [ -f "$strace_file" ]; then
+        echo "collecting strace log $strace_file"
+        file_list="$file_list $strace_file"
     fi
 done
 


### PR DESCRIPTION
These are only present if we enable debug builds using strace and could be large (e.g., GB) but worst case its our only mechanism of spotting issues that may arise in CI/CD