### PR TITLE
check all three scripts because old releases had a leftover old unwrap.sh

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -49,20 +49,29 @@ const child_process_1 = __nccwpck_require__(2081);
 const stream_1 = __nccwpck_require__(2781);
 const util_1 = __nccwpck_require__(3837);
 const streamPipeline = (0, util_1.promisify)(stream_1.pipeline);
-// FIXME: remove bundled scripts/ fallback once all deployed archives include
-// collect_observables.sh and collect_curiosity_logs.sh (i.e. after the first
-// release built with the updated curiosity-release Makefile).
-function resolveScript(name, installerDir) {
-    const archivePath = path.join(installerDir, name);
-    if (fs.existsSync(archivePath)) {
-        return archivePath;
+function resolveScripts(installerDir) {
+    const names = [
+        "unwrap.sh",
+        "collect_curiosity_logs.sh",
+        "collect_observables.sh",
+    ];
+    const archivePaths = names.map((n) => path.join(installerDir, n));
+    const bundleComplete = archivePaths.every((p) => fs.existsSync(p));
+    if (bundleComplete) {
+        return {
+            unwrap: archivePaths[0],
+            logs: archivePaths[1],
+            observables: archivePaths[2],
+        };
     }
-    const bundledPath = path.join(__dirname, "../scripts", name);
-    if (fs.existsSync(bundledPath)) {
-        core.info(`${name} not in archive, using bundled fallback`);
-        return bundledPath;
+    core.info("Bundle incomplete, using local scripts/ fallback for all");
+    const localDir = path.join(__dirname, "../scripts");
+    const localPaths = names.map((n) => path.join(localDir, n));
+    const allLocal = localPaths.every((p) => fs.existsSync(p));
+    if (!allLocal) {
+        throw new Error("Scripts missing from both archive and local scripts/");
     }
-    throw new Error(`Script ${name} not found in archive or bundled scripts`);
+    return { unwrap: localPaths[0], logs: localPaths[1], observables: localPaths[2] };
 }
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -106,12 +115,10 @@ function cleanup() {
             const curiosityHome = core.getState("curiosityHome") || "/mnt/curiosity";
             const scriptEnv = Object.assign(Object.assign({}, process.env), { CURIOSITY_HOME: curiosityHome });
             const installerDir = path.join(archivePath, "curiosity-installer");
-            const unwrapScript = resolveScript("unwrap.sh", installerDir);
-            const logsScript = resolveScript("collect_curiosity_logs.sh", installerDir);
-            const observablesScript = resolveScript("collect_observables.sh", installerDir);
-            (0, child_process_1.execSync)(`bash ${unwrapScript}`, { stdio: "inherit", env: scriptEnv });
-            (0, child_process_1.execSync)(`bash ${logsScript}`, { stdio: "inherit", env: scriptEnv });
-            (0, child_process_1.execSync)(`bash ${observablesScript}`, { stdio: "inherit", env: scriptEnv });
+            const scripts = resolveScripts(installerDir);
+            (0, child_process_1.execSync)(`bash ${scripts.unwrap}`, { stdio: "inherit", env: scriptEnv });
+            (0, child_process_1.execSync)(`bash ${scripts.logs}`, { stdio: "inherit", env: scriptEnv });
+            (0, child_process_1.execSync)(`bash ${scripts.observables}`, { stdio: "inherit", env: scriptEnv });
             core.info(`Done emitting observables json - calling chalk env`);
             (0, child_process_1.execSync)(`chalk env`, { stdio: "inherit" });
             core.info(`Done`);

--- a/lib/main.js
+++ b/lib/main.js
@@ -42,20 +42,29 @@ const child_process_1 = require("child_process");
 const stream_1 = require("stream");
 const util_1 = require("util");
 const streamPipeline = (0, util_1.promisify)(stream_1.pipeline);
-// FIXME: remove bundled scripts/ fallback once all deployed archives include
-// collect_observables.sh and collect_curiosity_logs.sh (i.e. after the first
-// release built with the updated curiosity-release Makefile).
-function resolveScript(name, installerDir) {
-    const archivePath = path.join(installerDir, name);
-    if (fs.existsSync(archivePath)) {
-        return archivePath;
+function resolveScripts(installerDir) {
+    const names = [
+        "unwrap.sh",
+        "collect_curiosity_logs.sh",
+        "collect_observables.sh",
+    ];
+    const archivePaths = names.map((n) => path.join(installerDir, n));
+    const bundleComplete = archivePaths.every((p) => fs.existsSync(p));
+    if (bundleComplete) {
+        return {
+            unwrap: archivePaths[0],
+            logs: archivePaths[1],
+            observables: archivePaths[2],
+        };
     }
-    const bundledPath = path.join(__dirname, "../scripts", name);
-    if (fs.existsSync(bundledPath)) {
-        core.info(`${name} not in archive, using bundled fallback`);
-        return bundledPath;
+    core.info("Bundle incomplete, using local scripts/ fallback for all");
+    const localDir = path.join(__dirname, "../scripts");
+    const localPaths = names.map((n) => path.join(localDir, n));
+    const allLocal = localPaths.every((p) => fs.existsSync(p));
+    if (!allLocal) {
+        throw new Error("Scripts missing from both archive and local scripts/");
     }
-    throw new Error(`Script ${name} not found in archive or bundled scripts`);
+    return { unwrap: localPaths[0], logs: localPaths[1], observables: localPaths[2] };
 }
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -99,12 +108,10 @@ function cleanup() {
             const curiosityHome = core.getState("curiosityHome") || "/mnt/curiosity";
             const scriptEnv = Object.assign(Object.assign({}, process.env), { CURIOSITY_HOME: curiosityHome });
             const installerDir = path.join(archivePath, "curiosity-installer");
-            const unwrapScript = resolveScript("unwrap.sh", installerDir);
-            const logsScript = resolveScript("collect_curiosity_logs.sh", installerDir);
-            const observablesScript = resolveScript("collect_observables.sh", installerDir);
-            (0, child_process_1.execSync)(`bash ${unwrapScript}`, { stdio: "inherit", env: scriptEnv });
-            (0, child_process_1.execSync)(`bash ${logsScript}`, { stdio: "inherit", env: scriptEnv });
-            (0, child_process_1.execSync)(`bash ${observablesScript}`, { stdio: "inherit", env: scriptEnv });
+            const scripts = resolveScripts(installerDir);
+            (0, child_process_1.execSync)(`bash ${scripts.unwrap}`, { stdio: "inherit", env: scriptEnv });
+            (0, child_process_1.execSync)(`bash ${scripts.logs}`, { stdio: "inherit", env: scriptEnv });
+            (0, child_process_1.execSync)(`bash ${scripts.observables}`, { stdio: "inherit", env: scriptEnv });
             core.info(`Done emitting observables json - calling chalk env`);
             (0, child_process_1.execSync)(`chalk env`, { stdio: "inherit" });
             core.info(`Done`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,20 +10,35 @@ import { promisify } from "util";
 
 const streamPipeline = promisify(pipeline);
 
-// FIXME: remove bundled scripts/ fallback once all deployed archives include
-// collect_observables.sh and collect_curiosity_logs.sh (i.e. after the first
-// release built with the updated curiosity-release Makefile).
-function resolveScript(name: string, installerDir: string): string {
-  const archivePath = path.join(installerDir, name);
-  if (fs.existsSync(archivePath)) {
-    return archivePath;
+function resolveScripts(installerDir: string): {
+  unwrap: string;
+  logs: string;
+  observables: string;
+} {
+  const names = [
+    "unwrap.sh",
+    "collect_curiosity_logs.sh",
+    "collect_observables.sh",
+  ];
+  const archivePaths = names.map((n) => path.join(installerDir, n));
+  const bundleComplete = archivePaths.every((p) => fs.existsSync(p));
+
+  if (bundleComplete) {
+    return {
+      unwrap: archivePaths[0],
+      logs: archivePaths[1],
+      observables: archivePaths[2],
+    };
   }
-  const bundledPath = path.join(__dirname, "../scripts", name);
-  if (fs.existsSync(bundledPath)) {
-    core.info(`${name} not in archive, using bundled fallback`);
-    return bundledPath;
+
+  core.info("Bundle incomplete, using local scripts/ fallback for all");
+  const localDir = path.join(__dirname, "../scripts");
+  const localPaths = names.map((n) => path.join(localDir, n));
+  const allLocal = localPaths.every((p) => fs.existsSync(p));
+  if (!allLocal) {
+    throw new Error("Scripts missing from both archive and local scripts/");
   }
-  throw new Error(`Script ${name} not found in archive or bundled scripts`);
+  return { unwrap: localPaths[0], logs: localPaths[1], observables: localPaths[2] };
 }
 
 async function run(): Promise<void> {
@@ -77,16 +92,11 @@ async function cleanup(): Promise<void> {
     const scriptEnv = { ...process.env, CURIOSITY_HOME: curiosityHome };
     const installerDir = path.join(archivePath, "curiosity-installer");
 
-    const unwrapScript = resolveScript("unwrap.sh", installerDir);
-    const logsScript = resolveScript("collect_curiosity_logs.sh", installerDir);
-    const observablesScript = resolveScript(
-      "collect_observables.sh",
-      installerDir,
-    );
+    const scripts = resolveScripts(installerDir);
 
-    execSync(`bash ${unwrapScript}`, { stdio: "inherit", env: scriptEnv });
-    execSync(`bash ${logsScript}`, { stdio: "inherit", env: scriptEnv });
-    execSync(`bash ${observablesScript}`, { stdio: "inherit", env: scriptEnv });
+    execSync(`bash ${scripts.unwrap}`, { stdio: "inherit", env: scriptEnv });
+    execSync(`bash ${scripts.logs}`, { stdio: "inherit", env: scriptEnv });
+    execSync(`bash ${scripts.observables}`, { stdio: "inherit", env: scriptEnv });
 
     core.info(`Done emitting observables json - calling chalk env`);
     execSync(`chalk env`, { stdio: "inherit" });


### PR DESCRIPTION
There was a legacy unwrap.sh in the old releases which caused the wrong script to be getting called. What we want is to use all three scripts from this action if ALL of them are missing.